### PR TITLE
fixed gtouchable processing, major improvements in gtouchable debugging

### DIFF
--- a/gdynamicDigitization/gdynamicdigitization.cc
+++ b/gdynamicDigitization/gdynamicdigitization.cc
@@ -4,6 +4,7 @@
 // glibrary
 #include "gtranslationTableConventions.h"
 #include "gdataConventions.h"
+#include "gtouchableConventions.h"
 
 // c++
 using std::cerr;
@@ -133,15 +134,21 @@ float GDynamicDigitization:: processStepTime(GTouchable *gTouchID, G4Step* thisS
 }
 
 
-// if not overloaded, returns a vector with a single touchable, with cell time index based on processStepTime
+// if not overloaded, returns:
+// a vector with a single touchable, with cell time index based on processStepTime if the time index is the same as the gTouchID's (or if it wasn't set)
+// a vectory with two touchables, one with the original gtouchID time index, and one with the new one
 vector<GTouchable*> GDynamicDigitization::processTouchable(GTouchable *gTouchID, G4Step* thisStep) {
-	
+
 	float stepTimeAtElectronics = processStepTime(gTouchID, thisStep);
-	
-	gTouchID->assignStepTimeAtElectronicsIndex(readoutSpecs->timeCellIndex(stepTimeAtElectronics));
-	
-	return { gTouchID };
-	
+    float stepTimeAtElectronicsIndex = readoutSpecs->timeCellIndex(stepTimeAtElectronics);
+
+    if ( stepTimeAtElectronicsIndex == gTouchID->getStepTimeAtElectronicsIndex() || gTouchID->getStepTimeAtElectronicsIndex() == GTOUCHABLEUNSETTIMEINDEX) {
+        gTouchID->assignStepTimeAtElectronicsIndex(stepTimeAtElectronicsIndex);
+        return { gTouchID };
+    } else {
+        return { gTouchID, new GTouchable(gTouchID, stepTimeAtElectronicsIndex) };
+    }
+
 }
 
 

--- a/gtouchable/gtouchable.h
+++ b/gtouchable/gtouchable.h
@@ -53,6 +53,11 @@ public:
 	// to register a new gtouchable in the sensitive detector gtouchable map
 	GTouchable(string digitization, string gidentityString, vector<double> dimensions, bool verb = false);
 
+    // copy constructor called in the non-overloaded processTouchable:
+    // used in case the stepTimeIndex of the hit is different from the gtouchable one
+    GTouchable(const GTouchable* baseGT, int newTimeIndex);
+
+
 	// copy constructor called in processTouchable
 	// used for energy sharing (keeps time as is)
 	// need to provide the gidentity
@@ -74,12 +79,12 @@ private:
 	int trackId;
 	
 	// set by processGTouchable in the digitization plugin. Defaulted to 1. Used to share energy / create new hits.
-	// Energy Multiplier. By default it is 1, but energy could be shared (or created) among volumes
+	// Energy Multiplier. By default, it is 1, but energy could be shared (or created) among volumes
 	float  eMultiplier;
 	
 	// stepTimeAtElectronicsIndex is used to determine if a hit is within
 	// an existing detector readout electronic time window
-	// stepTimeAtElectronicsIndex is set using using assignStepTimeAtElectronicsIndex
+	// stepTimeAtElectronicsIndex is set using assignStepTimeAtElectronicsIndex
 	// in gDynamicDigitization using the greadoutSpecs
 	int stepTimeAtElectronicsIndex;
 
@@ -87,7 +92,7 @@ private:
 	friend ostream &operator<<(ostream &stream, GTouchable gtouchable);
 
 	// could be used in GDynamicDigitization when the dimensions are needed
-	vector<double> detectorDimenions;
+	vector<double> detectorDimensions;
 
 public:
 	// Overloaded "==" operator for the class 'GTouchable'
@@ -101,10 +106,12 @@ public:
 
 	inline void assignStepTimeAtElectronicsIndex(int timeIndex) { stepTimeAtElectronicsIndex = timeIndex; }
 
+    inline const int getStepTimeAtElectronicsIndex() const { return stepTimeAtElectronicsIndex; }
+
 // api
 public:
 	inline const vector<GIdentifier> getIdentity() const {return gidentity;}
-	inline const vector<double> getDetectorDimensions() const {return detectorDimenions;}
+	inline const vector<double> getDetectorDimensions() const {return detectorDimensions;}
 
 };
 

--- a/gtouchable/gtouchableConventions.h
+++ b/gtouchable/gtouchableConventions.h
@@ -8,5 +8,6 @@
 #define FLUXNAME      "flux"
 #define COUNTERNAME   "particleCounter"
 #define DOSIMETERNAME "dosimeter"
+#define GTOUCHABLEUNSETTIMEINDEX -1
 
 #endif

--- a/release_notes/1.4.md
+++ b/release_notes/1.4.md
@@ -16,3 +16,6 @@
 - verbosity option for glibrary classes conforms to same description
 - testing all sci-g examples
 - added GEMCDB_ENV to list of location for sqlite database
+- fixed gtouchable processing: when step time is on another time index, the non-overloaded processTouchable returns 
+  a vector of gtouchable containing the step gtouchable and a new one with the new time index 
+- major improvements in gtouchable debugging


### PR DESCRIPTION
- fixed gtouchable processing: when step time is on another time index, the non-overloaded processTouchable returns 
  a vector of gtouchable containing the step gtouchable and a new one with the new time index 
- major improvements in gtouchable debugging logs
